### PR TITLE
refactor: convert from callbacks to async

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ stages:
 
 node_js:
   - '10'
+  - '12'
 
 os:
   - linux
@@ -21,7 +22,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
-  "pre-commit": [
-    "lint",
-    "test"
+  "pre-push": [
+    "lint"
   ],
   "author": "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
   "license": "MIT",
@@ -38,18 +37,17 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-record",
   "devDependencies": {
-    "aegir": "^18.2.2",
+    "aegir": "^20.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-crypto": "libp2p/js-libp2p-crypto#feat/async-await",
-    "peer-id": "libp2p/js-peer-id#feat/async-await",
-    "pre-commit": "^1.2.2"
+    "libp2p-crypto": "~0.17.0",
+    "peer-id": "~0.13.2"
   },
   "dependencies": {
     "buffer-split": "^1.0.0",
     "err-code": "^1.1.2",
-    "multihashes": "~0.4.14",
-    "multihashing-async": "multiformats/js-multihashing-async#feat/async-iterators",
+    "multihashes": "~0.4.15",
+    "multihashing-async": "~0.7.0",
     "protons": "^1.0.1"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -41,16 +41,15 @@
     "aegir": "^18.2.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-crypto": "~0.16.1",
-    "peer-id": "~0.12.2",
+    "libp2p-crypto": "libp2p/js-libp2p-crypto#feat/async-await",
+    "peer-id": "libp2p/js-peer-id#feat/async-await",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
-    "async": "^2.6.2",
     "buffer-split": "^1.0.0",
     "err-code": "^1.1.2",
     "multihashes": "~0.4.14",
-    "multihashing-async": "~0.6.0",
+    "multihashing-async": "multiformats/js-multihashing-async#feat/async-iterators",
     "protons": "^1.0.1"
   },
   "contributors": [

--- a/src/selection.js
+++ b/src/selection.js
@@ -15,7 +15,7 @@ const bestRecord = (selectors, k, records) => {
   if (records.length === 0) {
     const errMsg = `No records given`
 
-    throw errcode(new Error(errMsg), 'ERR_NO_RECORDS_RECEIVED')
+    throw errcode(errMsg, 'ERR_NO_RECORDS_RECEIVED')
   }
 
   const parts = bsplit(k, Buffer.from('/'))
@@ -23,7 +23,7 @@ const bestRecord = (selectors, k, records) => {
   if (parts.length < 3) {
     const errMsg = `Record key does not have a selector function`
 
-    throw errcode(new Error(errMsg), 'ERR_NO_SELECTOR_FUNCTION_FOR_RECORD_KEY')
+    throw errcode(errMsg, 'ERR_NO_SELECTOR_FUNCTION_FOR_RECORD_KEY')
   }
 
   const selector = selectors[parts[1].toString()]
@@ -31,7 +31,7 @@ const bestRecord = (selectors, k, records) => {
   if (!selector) {
     const errMsg = `Unrecognized key prefix: ${parts[1]}`
 
-    throw errcode(new Error(errMsg), 'ERR_UNRECOGNIZED_KEY_PREFIX')
+    throw errcode(errMsg, 'ERR_UNRECOGNIZED_KEY_PREFIX')
   }
 
   return selector(k, records)

--- a/src/validator.js
+++ b/src/validator.js
@@ -26,7 +26,7 @@ const verifyRecord = (validators, record) => {
   if (!validator) {
     const errMsg = `Invalid record keytype`
 
-    throw errcode(new Error(errMsg), 'ERR_INVALID_RECORD_KEY_TYPE')
+    throw errcode(errMsg, 'ERR_INVALID_RECORD_KEY_TYPE')
   }
 
   return validator.func(key, record.value)

--- a/src/validator.js
+++ b/src/validator.js
@@ -6,19 +6,19 @@ const errcode = require('err-code')
 /**
  * Checks a record and ensures it is still valid.
  * It runs the needed validators.
+ * If verification fails the returned Promise will reject with the error.
  *
  * @param {Object} validators
  * @param {Record} record
- * @param {function(Error)} callback
- * @returns {undefined}
+ * @returns {Promise}
  */
-const verifyRecord = (validators, record, callback) => {
+const verifyRecord = (validators, record) => {
   const key = record.key
   const parts = bsplit(key, Buffer.from('/'))
 
   if (parts.length < 3) {
     // No validator available
-    return callback()
+    return
   }
 
   const validator = validators[parts[1].toString()]
@@ -26,10 +26,10 @@ const verifyRecord = (validators, record, callback) => {
   if (!validator) {
     const errMsg = `Invalid record keytype`
 
-    return callback(errcode(new Error(errMsg), 'ERR_INVALID_RECORD_KEY_TYPE'))
+    throw errcode(new Error(errMsg), 'ERR_INVALID_RECORD_KEY_TYPE')
   }
 
-  validator.func(key, record.value, callback)
+  return validator.func(key, record.value)
 }
 
 module.exports = {

--- a/src/validators/public-key.js
+++ b/src/validators/public-key.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const multihashing = require('multihashing-async')
+const errcode = require('err-code')
 
 /**
  * Validator for publick key records.
@@ -14,17 +15,17 @@ const multihashing = require('multihashing-async')
  */
 const validatePublicKeyRecord = async (key, publicKey) => {
   if (!Buffer.isBuffer(key)) {
-    throw new Error('"key" must be a Buffer')
+    throw errcode('"key" must be a Buffer', 'ERR_INVALID_RECORD_KEY_NOT_BUFFER')
   }
 
-  if (key.length < 3) {
-    throw new Error('invalid public key record')
+  if (key.length < 5) {
+    throw errcode('invalid public key record', 'ERR_INVALID_RECORD_KEY_TOO_SHORT')
   }
 
   const prefix = key.slice(0, 4).toString()
 
   if (prefix !== '/pk/') {
-    throw new Error('key was not prefixed with /pk/')
+    throw errcode('key was not prefixed with /pk/', 'ERR_INVALID_RECORD_KEY_BAD_PREFIX')
   }
 
   const keyhash = key.slice(4)
@@ -32,7 +33,7 @@ const validatePublicKeyRecord = async (key, publicKey) => {
   const publicKeyHash = await multihashing(publicKey, 'sha2-256')
 
   if (!keyhash.equals(publicKeyHash)) {
-    throw new Error('public key does not match passed in key')
+    throw errcode('public key does not match passed in key', 'ERR_INVALID_RECORD_HASH_MISMATCH')
   }
 }
 

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -5,8 +5,6 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const waterfall = require('async/waterfall')
-const each = require('async/each')
 const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
 
@@ -47,57 +45,47 @@ describe('validator', () => {
   let hash
   let cases
 
-  before((done) => {
-    waterfall([
-      (cb) => crypto.keys.generateKeyPair('rsa', 1024, cb),
-      (pair, cb) => {
-        key = pair
-        pair.public.hash(cb)
-      },
-      (_hash, cb) => {
-        hash = _hash
-        cases = generateCases(hash)
-        cb()
-      }
-    ], done)
+  before(async () => {
+    key = await crypto.keys.generateKeyPair('rsa', 1024)
+    hash = await key.public.hash()
+    cases = generateCases(hash)
   })
 
   describe('verifyRecord', () => {
-    it('calls matching validator', (done) => {
+    it('calls matching validator', () => {
       const k = Buffer.from('/hello/you')
       const rec = new Record(k, Buffer.from('world'), new PeerId(hash))
 
       const validators = {
         hello: {
-          func (key, value, cb) {
+          func (key, value) {
             expect(key).to.eql(k)
             expect(value).to.eql(Buffer.from('world'))
-            cb()
           },
           sign: false
         }
       }
-      validator.verifyRecord(validators, rec, done)
+      return validator.verifyRecord(validators, rec)
     })
 
-    it('calls not matching any validator', (done) => {
+    it('calls not matching any validator', () => {
       const k = Buffer.from('/hallo/you')
       const rec = new Record(k, Buffer.from('world'), new PeerId(hash))
 
       const validators = {
         hello: {
-          func (key, value, cb) {
+          func (key, value) {
             expect(key).to.eql(k)
             expect(value).to.eql(Buffer.from('world'))
-            cb()
           },
           sign: false
         }
       }
-      validator.verifyRecord(validators, rec, (err) => {
-        expect(err).to.exist()
-        done()
-      })
+      return expect(
+        () => validator.verifyRecord(validators, rec)
+      ).to.throw(
+        /Invalid record keytype/
+      )
     })
   })
 
@@ -107,40 +95,36 @@ describe('validator', () => {
     })
 
     describe('public key', () => {
-      it('exports func and sing', () => {
+      it('exports func and sign', () => {
         const pk = validator.validators.pk
 
         expect(pk).to.have.property('func')
         expect(pk).to.have.property('sign', false)
       })
 
-      it('does not error on valid record', (done) => {
-        each(cases.valid.publicKey, (k, cb) => {
-          validator.validators.pk.func(k, key.public.bytes, cb)
-        }, done)
+      it('does not error on valid record', () => {
+        return Promise.all(cases.valid.publicKey, (k) => {
+          return validator.validators.pk.func(k, key.public.bytes)
+        })
       })
 
-      it('throws on invalid records', (done) => {
-        each(cases.invalid.publicKey, (k, cb) => {
-          validator.validators.pk.func(k, key.public.bytes, (err) => {
-            expect(err).to.exist()
-            cb()
-          })
-        }, done)
+      it('throws on invalid records', () => {
+        return Promise.all(cases.invalid.publicKey, (k) => {
+          return expect(
+            () => validator.validators.pk.func(k, key.public.bytes)
+          ).to.throw()
+        })
       })
     })
   })
 
   describe('go interop', () => {
-    it('record with key from from go', (done) => {
+    it('record with key from from go', async () => {
       const pubKey = crypto.keys.unmarshalPublicKey(fixture.publicKey)
 
-      pubKey.hash((err, hash) => {
-        expect(err).to.not.exist()
-        const k = Buffer.concat([Buffer.from('/pk/'), hash])
-
-        validator.validators.pk.func(k, pubKey.bytes, done)
-      })
+      const hash = await pubKey.hash()
+      const k = Buffer.concat([Buffer.from('/pk/'), hash])
+      return validator.validators.pk.func(k, pubKey.bytes)
     })
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: All places in the API that used callbacks are now replaced with async/await

Needs the following PRs:

- [x] [js-peer-id#87](https://github.com/libp2p/js-peer-id/pull/87)
- [x] [multihashing-async#37](https://github.com/multiformats/js-multihashing-async/pull/37)
- [x] [js-libp2p-crypto#131](https://github.com/libp2p/js-libp2p-crypto/pull/131)

Note that currently [js-libp2p-crypto#131](https://github.com/libp2p/js-libp2p-crypto/pull/131) depends on [multihashing-async#master](https://github.com/multiformats/js-multihashing-async), whereas this PR depends on [multihashing-async#37](https://github.com/multiformats/js-multihashing-async/pull/37). So [js-libp2p-crypto#131](https://github.com/libp2p/js-libp2p-crypto/pull/131) will need to be updated to depend on [multihashing-async#37](https://github.com/multiformats/js-multihashing-async/pull/37) before this PR can be finished.