### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-libp2p-blue.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 [![Coverage Status](https://coveralls.io/repos/github/libp2p/js-libp2p-record/badge.svg?branch=master)](https://coveralls.io/github/libp2p/js-libp2p-record?branch=master)
 [![Travis CI](https://travis-ci.org/libp2p/js-libp2p-record.svg?branch=master)](https://travis-ci.org/libp2p/js-libp2p-record)

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-record",
   "devDependencies": {
-    "aegir": "^18.1.1",
+    "aegir": "^18.2.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-crypto": "~0.16.0",
+    "libp2p-crypto": "~0.16.1",
     "peer-id": "~0.12.2",
     "pre-commit": "^1.2.2"
   },
@@ -51,7 +51,7 @@
     "err-code": "^1.1.2",
     "left-pad": "^1.3.0",
     "multihashes": "~0.4.14",
-    "multihashing-async": "~0.5.2",
+    "multihashing-async": "~0.6.0",
     "protons": "^1.0.1"
   },
   "contributors": [


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated