### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,18 +38,16 @@
   "homepage": "https://github.com/libp2p/js-libp2p-record",
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
-    "ipfs-utils": "^2.3.1",
-    "libp2p-crypto": "~0.17.0",
-    "multibase": "^2.0.0",
-    "peer-id": "~0.13.6"
+    "libp2p-crypto": "^0.18.0",
+    "multibase": "^3.0.0",
+    "peer-id": "^0.14.0"
   },
   "dependencies": {
     "err-code": "^2.0.0",
-    "multihashes": "^1.0.1",
-    "multihashing-async": "^1.0.0",
-    "protons": "^1.2.1"
+    "multihashes": "^3.0.1",
+    "multihashing-async": "^2.0.1",
+    "protons": "^2.0.0",
+    "uint8arrays": "^1.1.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const errcode = require('err-code')
-const { utf8Decoder } = require('./utils')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 /**
  * Select the best record out of the given records.
@@ -18,7 +18,7 @@ const bestRecord = (selectors, k, records) => {
     throw errcode(new Error(errMsg), 'ERR_NO_RECORDS_RECEIVED')
   }
 
-  const kStr = utf8Decoder.decode(k)
+  const kStr = uint8ArrayToString(k)
   const parts = kStr.split('/')
 
   if (parts.length < 3) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,5 @@
 'use strict'
 
-const TextDecoder = require('ipfs-utils/src/text-decoder')
-const utf8Decoder = new TextDecoder('utf8')
-
-module.exports.utf8Decoder = utf8Decoder
-
 /**
  * Convert a JavaScript date into an `RFC3339Nano` formatted
  * string.
@@ -56,22 +51,4 @@ module.exports.parseRFC3339 = (time) => {
   const millisecond = parseInt(m[7].slice(0, -6), 10)
 
   return new Date(Date.UTC(year, month, date, hour, minute, second, millisecond))
-}
-
-module.exports.uint8ArraysEqual = (arr1, arr2) => {
-  if (arr1 === arr2) {
-    return true
-  }
-
-  if (arr1.byteLength !== arr2.byteLength) {
-    return false
-  }
-
-  for (let i = 0; i < arr1.byteLength; i++) {
-    if (arr1[i] !== arr2[i]) {
-      return false
-    }
-  }
-
-  return true
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const errcode = require('err-code')
-const { utf8Decoder } = require('./utils')
+const uint8ArrayToString = require('uint8arrays/to-string')
+
 /**
  * Checks a record and ensures it is still valid.
  * It runs the needed validators.
@@ -13,7 +14,7 @@ const { utf8Decoder } = require('./utils')
  */
 const verifyRecord = (validators, record) => {
   const key = record.key
-  const keyString = utf8Decoder.decode(key)
+  const keyString = uint8ArrayToString(key)
   const parts = keyString.split('/')
 
   if (parts.length < 3) {

--- a/src/validators/public-key.js
+++ b/src/validators/public-key.js
@@ -2,7 +2,8 @@
 
 const multihashing = require('multihashing-async')
 const errcode = require('err-code')
-const { utf8Decoder, uint8ArraysEqual } = require('../utils')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayEquals = require('uint8arrays/equals')
 
 /**
  * Validator for public key records.
@@ -23,7 +24,7 @@ const validatePublicKeyRecord = async (key, publicKey) => {
     throw errcode(new Error('invalid public key record'), 'ERR_INVALID_RECORD_KEY_TOO_SHORT')
   }
 
-  const prefix = utf8Decoder.decode(key.subarray(0, 4))
+  const prefix = uint8ArrayToString(key.subarray(0, 4))
 
   if (prefix !== '/pk/') {
     throw errcode(new Error('key was not prefixed with /pk/'), 'ERR_INVALID_RECORD_KEY_BAD_PREFIX')
@@ -33,7 +34,7 @@ const validatePublicKeyRecord = async (key, publicKey) => {
 
   const publicKeyHash = await multihashing(publicKey, 'sha2-256')
 
-  if (!uint8ArraysEqual(keyhash, publicKeyHash)) {
+  if (!uint8ArrayEquals(keyhash, publicKeyHash)) {
     throw errcode(new Error('public key does not match passed in key'), 'ERR_INVALID_RECORD_HASH_MISMATCH')
   }
 }

--- a/test/record.spec.js
+++ b/test/record.spec.js
@@ -1,10 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
-const { utf8TextEncoder } = require('./utils')
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const libp2pRecord = require('../src')
 const Record = libp2pRecord.Record
 
@@ -15,28 +13,28 @@ const date = new Date(Date.UTC(2012, 1, 25, 10, 10, 10, 10))
 describe('record', () => {
   it('new', () => {
     const rec = new Record(
-      utf8TextEncoder.encode('hello'),
-      utf8TextEncoder.encode('world')
+      uint8ArrayFromString('hello'),
+      uint8ArrayFromString('world')
     )
 
-    expect(rec).to.have.property('key').eql(utf8TextEncoder.encode('hello'))
-    expect(rec).to.have.property('value').eql(utf8TextEncoder.encode('world'))
+    expect(rec).to.have.property('key').eql(uint8ArrayFromString('hello'))
+    expect(rec).to.have.property('value').eql(uint8ArrayFromString('world'))
   })
 
   it('serialize & deserialize', () => {
-    const rec = new Record(utf8TextEncoder.encode('hello'), utf8TextEncoder.encode('world'), date)
+    const rec = new Record(uint8ArrayFromString('hello'), uint8ArrayFromString('world'), date)
     const dec = Record.deserialize(rec.serialize())
 
-    expect(dec).to.have.property('key').eql(utf8TextEncoder.encode('hello'))
-    expect(dec).to.have.property('value').eql(utf8TextEncoder.encode('world'))
+    expect(dec).to.have.property('key').eql(uint8ArrayFromString('hello'))
+    expect(dec).to.have.property('value').eql(uint8ArrayFromString('world'))
     expect(dec.timeReceived).to.be.eql(date)
   })
 
   describe('go interop', () => {
     it('no signature', () => {
       const dec = Record.deserialize(fixture.serialized)
-      expect(dec).to.have.property('key').eql(utf8TextEncoder.encode('hello'))
-      expect(dec).to.have.property('value').eql(utf8TextEncoder.encode('world'))
+      expect(dec).to.have.property('key').eql(uint8ArrayFromString('hello'))
+      expect(dec).to.have.property('value').eql(uint8ArrayFromString('world'))
     })
   })
 })

--- a/test/selection.spec.js
+++ b/test/selection.spec.js
@@ -2,18 +2,18 @@
 /* eslint-env mocha */
 'use strict'
 
-var expect = require('chai').expect
-const { utf8TextEncoder } = require('./utils')
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const libp2pRecord = require('../src')
 const selection = libp2pRecord.selection
 
-const records = [new Uint8Array(), utf8TextEncoder.encode('hello')]
+const records = [new Uint8Array(), uint8ArrayFromString('hello')]
 
 describe('selection', () => {
   describe('bestRecord', () => {
     it('throws no records given when no records received', () => {
       expect(
-        () => selection.bestRecord({}, utf8TextEncoder.encode('/'), [])
+        () => selection.bestRecord({}, uint8ArrayFromString('/'), [])
       ).to.throw(
         /No records given/
       )
@@ -21,7 +21,7 @@ describe('selection', () => {
 
     it('throws on missing selector in the record key', () => {
       expect(
-        () => selection.bestRecord({}, utf8TextEncoder.encode('/'), records)
+        () => selection.bestRecord({}, uint8ArrayFromString('/'), records)
       ).to.throw(
         /Record key does not have a selector function/
       )
@@ -29,7 +29,7 @@ describe('selection', () => {
 
     it('throws on unknown key prefix', () => {
       expect(
-        () => selection.bestRecord({ world () {} }, utf8TextEncoder.encode('/hello/'), records)
+        () => selection.bestRecord({ world () {} }, uint8ArrayFromString('/hello/'), records)
       ).to.throw(
         /Unrecognized key prefix: hello/
       )
@@ -38,7 +38,7 @@ describe('selection', () => {
     it('returns the index from the matching selector', () => {
       const selectors = {
         hello (k, recs) {
-          expect(k).to.be.eql(utf8TextEncoder.encode('/hello/world'))
+          expect(k).to.be.eql(uint8ArrayFromString('/hello/world'))
           expect(recs).to.be.eql(records)
 
           return 1
@@ -46,7 +46,7 @@ describe('selection', () => {
       }
 
       expect(
-        selection.bestRecord(selectors, utf8TextEncoder.encode('/hello/world'), records)
+        selection.bestRecord(selectors, uint8ArrayFromString('/hello/world'), records)
       ).to.equal(
         1
       )
@@ -56,7 +56,7 @@ describe('selection', () => {
   describe('selectors', () => {
     it('public key', () => {
       expect(
-        selection.selectors.pk(utf8TextEncoder.encode('/hello/world'), records)
+        selection.selectors.pk(uint8ArrayFromString('/hello/world'), records)
       ).to.equal(
         0
       )

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,0 @@
-'use strict'
-
-const TextEncoder = require('ipfs-utils/src/text-encoder')
-const utf8TextEncoder = new TextEncoder('utf8')
-
-module.exports.utf8TextEncoder = utf8TextEncoder

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
-
+const { expect } = require('aegir/utils/chai')
 const utils = require('../src/utils')
 
 const dates = [[

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -2,12 +2,10 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
-const { utf8TextEncoder } = require('./utils')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const libp2pRecord = require('../src')
 const validator = libp2pRecord.validator
 const Record = libp2pRecord.Record
@@ -19,7 +17,7 @@ const generateCases = (hash) => {
     valid: {
       publicKey: [
         Uint8Array.of(
-          ...utf8TextEncoder.encode('/pk/'),
+          ...uint8ArrayFromString('/pk/'),
           ...hash
         )
       ]
@@ -27,10 +25,10 @@ const generateCases = (hash) => {
     invalid: {
       publicKey: [
         // missing hashkey
-        [utf8TextEncoder.encode('/pk/'), 'ERR_INVALID_RECORD_KEY_TOO_SHORT'],
+        [uint8ArrayFromString('/pk/'), 'ERR_INVALID_RECORD_KEY_TOO_SHORT'],
         // not the hash of a key
-        [Uint8Array.of(...utf8TextEncoder.encode('/pk/'),
-          ...utf8TextEncoder.encode('random')
+        [Uint8Array.of(...uint8ArrayFromString('/pk/'),
+          ...uint8ArrayFromString('random')
         ), 'ERR_INVALID_RECORD_HASH_MISMATCH'],
         // missing prefix
         [hash, 'ERR_INVALID_RECORD_KEY_BAD_PREFIX'],
@@ -54,14 +52,14 @@ describe('validator', () => {
 
   describe('verifyRecord', () => {
     it('calls matching validator', () => {
-      const k = utf8TextEncoder.encode('/hello/you')
-      const rec = new Record(k, utf8TextEncoder.encode('world'), new PeerId(hash))
+      const k = uint8ArrayFromString('/hello/you')
+      const rec = new Record(k, uint8ArrayFromString('world'), new PeerId(hash))
 
       const validators = {
         hello: {
           func (key, value) {
             expect(key).to.eql(k)
-            expect(value).to.eql(utf8TextEncoder.encode('world'))
+            expect(value).to.eql(uint8ArrayFromString('world'))
           },
           sign: false
         }
@@ -70,14 +68,14 @@ describe('validator', () => {
     })
 
     it('calls not matching any validator', () => {
-      const k = utf8TextEncoder.encode('/hallo/you')
-      const rec = new Record(k, utf8TextEncoder.encode('world'), new PeerId(hash))
+      const k = uint8ArrayFromString('/hallo/you')
+      const rec = new Record(k, uint8ArrayFromString('world'), new PeerId(hash))
 
       const validators = {
         hello: {
           func (key, value) {
             expect(key).to.eql(k)
-            expect(value).to.eql(utf8TextEncoder.encode('world'))
+            expect(value).to.eql(uint8ArrayFromString('world'))
           },
           sign: false
         }
@@ -128,7 +126,7 @@ describe('validator', () => {
       const pubKey = crypto.keys.unmarshalPublicKey(fixture.publicKey)
 
       const hash = await pubKey.hash()
-      const k = Uint8Array.of(...utf8TextEncoder.encode('/pk/'), ...hash)
+      const k = Uint8Array.of(...uint8ArrayFromString('/pk/'), ...hash)
       return validator.validators.pk.func(k, pubKey.bytes)
     })
   })


### PR DESCRIPTION
Pulls in the latest deps that swap node Buffers for Uint8Arrays

Also removes redundant modules

BREAKING CHANGES

- The updated deps return Uint8Arrays instead of Buffers so may be
  incompatible with previous versions