### PR TITLE
fix: auto select if only one record

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -34,6 +34,10 @@ const bestRecord = (selectors, k, records) => {
     throw errcode(new Error(errMsg), 'ERR_UNRECOGNIZED_KEY_PREFIX')
   }
 
+  if (records.length === 1) {
+    return 0
+  }
+
   return selector(k, records)
 }
 

--- a/test/selection.spec.js
+++ b/test/selection.spec.js
@@ -61,5 +61,13 @@ describe('selection', () => {
         0
       )
     })
+
+    it('returns the first record when there is only one to select', () => {
+      expect(
+        selection.selectors.pk(uint8ArrayFromString('/hello/world'), [records[0]])
+      ).to.equal(
+        0
+      )
+    })
   })
 })


### PR DESCRIPTION
If there's only one record, just select it, otherwise selector implementations all have to guard against that being the case.