### PR TITLE
fix: export selector/validators with the same name as their prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,8 +167,8 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "@libp2p/crypto": "^0.22.7",
-    "@libp2p/interfaces": "^1.3.3",
+    "@libp2p/crypto": "^0.22.9",
+    "@libp2p/interfaces": "^1.3.18",
     "aegir": "^36.1.3"
   }
 }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -46,5 +46,5 @@ function publickKey (k: Uint8Array, records: Uint8Array[]) {
 }
 
 export const selectors = {
-  publickKey
+  pk: publickKey
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -70,5 +70,5 @@ const publicKey = {
 }
 
 export const validators = {
-  publicKey
+  pk: publicKey
 }

--- a/test/selection.spec.ts
+++ b/test/selection.spec.ts
@@ -56,7 +56,7 @@ describe('selection', () => {
   describe('selectors', () => {
     it('public key', () => {
       expect(
-        selection.selectors.publickKey(uint8ArrayFromString('/hello/world'), records)
+        selection.selectors.pk(uint8ArrayFromString('/hello/world'), records)
       ).to.equal(
         0
       )
@@ -64,7 +64,7 @@ describe('selection', () => {
 
     it('returns the first record when there is only one to select', () => {
       expect(
-        selection.selectors.publickKey(uint8ArrayFromString('/hello/world'), [records[0]])
+        selection.selectors.pk(uint8ArrayFromString('/hello/world'), [records[0]])
       ).to.equal(
         0
       )

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -99,12 +99,12 @@ describe('validator', () => {
 
   describe('validators', () => {
     it('exports pk', () => {
-      expect(validator.validators).to.have.keys(['publicKey'])
+      expect(validator.validators).to.have.keys(['pk'])
     })
 
     describe('public key', () => {
       it('exports func and sign', () => {
-        const pk = validator.validators.publicKey
+        const pk = validator.validators.pk
 
         expect(pk).to.have.property('func')
         expect(pk).to.have.property('sign', false)
@@ -112,7 +112,7 @@ describe('validator', () => {
 
       it('does not error on valid record', async () => {
         return await Promise.all(cases.valid.publicKey.map(async (k) => {
-          return await validator.validators.publicKey.func(k, key.public.bytes)
+          return await validator.validators.pk.func(k, key.public.bytes)
         }))
       })
 
@@ -120,7 +120,7 @@ describe('validator', () => {
         return await Promise.all(cases.invalid.publicKey.map(async ({ data, code }) => {
           try {
             //
-            await validator.validators.publicKey.func(data, key.public.bytes)
+            await validator.validators.pk.func(data, key.public.bytes)
           } catch (err: any) {
             expect(err.code).to.eql(code)
             return
@@ -137,7 +137,7 @@ describe('validator', () => {
 
       const hash = await pubKey.hash()
       const k = Uint8Array.of(...uint8ArrayFromString('/pk/'), ...hash)
-      return await validator.validators.publicKey.func(k, pubKey.bytes)
+      return await validator.validators.pk.func(k, pubKey.bytes)
     })
   })
 })


### PR DESCRIPTION
So we don't have to map `publicKey` -> `pk` elsewhere.