### PR TITLE
chore: replace err-code with CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   },
   "dependencies": {
     "@libp2p/interface-dht": "^2.0.0",
-    "err-code": "^3.0.1",
+    "@libp2p/interfaces": "^3.2.0",
     "multiformats": "^11.0.0",
     "protons-runtime": "^4.0.1",
     "uint8arraylist": "^2.1.1",

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,4 +1,4 @@
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { Selectors } from '@libp2p/interface-dht'
 
@@ -9,7 +9,7 @@ export function bestRecord (selectors: Selectors, k: Uint8Array, records: Uint8A
   if (records.length === 0) {
     const errMsg = 'No records given'
 
-    throw errCode(new Error(errMsg), 'ERR_NO_RECORDS_RECEIVED')
+    throw new CodeError(errMsg, 'ERR_NO_RECORDS_RECEIVED')
   }
 
   const kStr = uint8ArrayToString(k)
@@ -18,7 +18,7 @@ export function bestRecord (selectors: Selectors, k: Uint8Array, records: Uint8A
   if (parts.length < 3) {
     const errMsg = 'Record key does not have a selector function'
 
-    throw errCode(new Error(errMsg), 'ERR_NO_SELECTOR_FUNCTION_FOR_RECORD_KEY')
+    throw new CodeError(errMsg, 'ERR_NO_SELECTOR_FUNCTION_FOR_RECORD_KEY')
   }
 
   const selector = selectors[parts[1].toString()]
@@ -26,7 +26,7 @@ export function bestRecord (selectors: Selectors, k: Uint8Array, records: Uint8A
   if (selector == null) {
     const errMsg = `Unrecognized key prefix: ${parts[1]}`
 
-    throw errCode(new Error(errMsg), 'ERR_UNRECOGNIZED_KEY_PREFIX')
+    throw new CodeError(errMsg, 'ERR_UNRECOGNIZED_KEY_PREFIX')
   }
 
   if (records.length === 1) {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,4 +1,4 @@
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { Libp2pRecord } from './index.js'
 import type { Validators } from '@libp2p/interface-dht'
@@ -25,7 +25,7 @@ export function verifyRecord (validators: Validators, record: Libp2pRecord) {
   if (validator == null) {
     const errMsg = 'Invalid record keytype'
 
-    throw errCode(new Error(errMsg), 'ERR_INVALID_RECORD_KEY_TYPE')
+    throw new CodeError(errMsg, 'ERR_INVALID_RECORD_KEY_TYPE')
   }
 
   return validator(key, record.value)
@@ -42,17 +42,17 @@ export function verifyRecord (validators: Validators, record: Libp2pRecord) {
  */
 const validatePublicKeyRecord = async (key: Uint8Array, publicKey: Uint8Array) => {
   if (!(key instanceof Uint8Array)) {
-    throw errCode(new Error('"key" must be a Uint8Array'), 'ERR_INVALID_RECORD_KEY_NOT_BUFFER')
+    throw new CodeError('"key" must be a Uint8Array', 'ERR_INVALID_RECORD_KEY_NOT_BUFFER')
   }
 
   if (key.byteLength < 5) {
-    throw errCode(new Error('invalid public key record'), 'ERR_INVALID_RECORD_KEY_TOO_SHORT')
+    throw new CodeError('invalid public key record', 'ERR_INVALID_RECORD_KEY_TOO_SHORT')
   }
 
   const prefix = uint8ArrayToString(key.subarray(0, 4))
 
   if (prefix !== '/pk/') {
-    throw errCode(new Error('key was not prefixed with /pk/'), 'ERR_INVALID_RECORD_KEY_BAD_PREFIX')
+    throw new CodeError('key was not prefixed with /pk/', 'ERR_INVALID_RECORD_KEY_BAD_PREFIX')
   }
 
   const keyhash = key.slice(4)
@@ -60,7 +60,7 @@ const validatePublicKeyRecord = async (key: Uint8Array, publicKey: Uint8Array) =
   const publicKeyHash = await sha256.digest(publicKey)
 
   if (!uint8ArrayEquals(keyhash, publicKeyHash.bytes)) {
-    throw errCode(new Error('public key does not match passed in key'), 'ERR_INVALID_RECORD_HASH_MISMATCH')
+    throw new CodeError('public key does not match passed in key', 'ERR_INVALID_RECORD_HASH_MISMATCH')
   }
 }
 


### PR DESCRIPTION
Replaces [err-code](https://github.com/IndigoUnited/js-err-code/blob/master/index.js) with [CodeError](https://github.com/libp2p/js-libp2p-interfaces/pull/314)

Related: [js-libp2p#1269](https://github.com/libp2p/js-libp2p/issues/1269)

Changes

- removes err-code from dependencies
- adds @libp2p/interfaces@3.2.0 to dependencies
- uses CodeError in place of err-code
